### PR TITLE
Add more options for opening SQLite databases - busy_timeout and journal_mode - and set busy time-out by default

### DIFF
--- a/src/include/sqlite_db.hpp
+++ b/src/include/sqlite_db.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "sqlite_utils.hpp"
+#include "storage/sqlite_options.hpp"
 
 namespace duckdb {
 class SQLiteStatement;
@@ -29,7 +30,7 @@ public:
 	sqlite3 *db;
 
 public:
-	static SQLiteDB Open(const string &path, bool is_read_only = true, bool is_shared = false);
+	static SQLiteDB Open(const string &path, const SQLiteOpenOptions &options, bool is_shared = false);
 	bool TryPrepare(const string &query, SQLiteStatement &result);
 	SQLiteStatement Prepare(const string &query);
 	void Execute(const string &query);

--- a/src/include/storage/sqlite_catalog.hpp
+++ b/src/include/storage/sqlite_catalog.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "duckdb/catalog/catalog.hpp"
-#include "duckdb/common/enums/access_mode.hpp"
+#include "sqlite_options.hpp"
 #include "sqlite_db.hpp"
 
 namespace duckdb {
@@ -17,11 +17,11 @@ class SQLiteSchemaEntry;
 
 class SQLiteCatalog : public Catalog {
 public:
-	explicit SQLiteCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode);
+	explicit SQLiteCatalog(AttachedDatabase &db_p, const string &path, SQLiteOpenOptions options);
 	~SQLiteCatalog();
 
 	string path;
-	AccessMode access_mode;
+	SQLiteOpenOptions options;
 
 public:
 	void Initialize(bool load_builtin) override;

--- a/src/sqlite_scanner.cpp
+++ b/src/sqlite_scanner.cpp
@@ -50,7 +50,9 @@ static unique_ptr<FunctionData> SqliteBind(ClientContext &context, TableFunction
 
 	SQLiteDB db;
 	SQLiteStatement stmt;
-	db = SQLiteDB::Open(result->file_name);
+	SQLiteOpenOptions options;
+	options.access_mode = AccessMode::READ_ONLY;
+	db = SQLiteDB::Open(result->file_name, options);
 
 	ColumnList columns;
 	vector<unique_ptr<Constraint>> constraints;
@@ -90,7 +92,9 @@ static void SqliteInitInternal(ClientContext &context, const SqliteBindData &bin
 	// function
 	local_state.stmt.Close();
 	if (!local_state.db) {
-		local_state.owned_db = SQLiteDB::Open(bind_data.file_name.c_str());
+		SQLiteOpenOptions options;
+		options.access_mode = AccessMode::READ_ONLY;
+		local_state.owned_db = SQLiteDB::Open(bind_data.file_name.c_str(), options);
 		local_state.db = &local_state.owned_db;
 	}
 
@@ -292,7 +296,9 @@ static void AttachFunction(ClientContext &context, TableFunctionInput &data_p, D
 		return;
 	}
 
-	SQLiteDB db = SQLiteDB::Open(data.file_name);
+	SQLiteOpenOptions options;
+	options.access_mode = AccessMode::READ_ONLY;
+	SQLiteDB db = SQLiteDB::Open(data.file_name, options);
 	auto dconn = Connection(context.db->GetDatabase(context));
 	{
 		auto tables = db.GetTables();

--- a/src/storage/sqlite_catalog.cpp
+++ b/src/storage/sqlite_catalog.cpp
@@ -6,10 +6,10 @@
 
 namespace duckdb {
 
-SQLiteCatalog::SQLiteCatalog(AttachedDatabase &db_p, const string &path, AccessMode access_mode)
-    : Catalog(db_p), path(path), access_mode(access_mode), in_memory(path == ":memory:"), active_in_memory(false) {
+SQLiteCatalog::SQLiteCatalog(AttachedDatabase &db_p, const string &path, SQLiteOpenOptions options_p)
+    : Catalog(db_p), path(path), options(std::move(options_p)), in_memory(path == ":memory:"), active_in_memory(false) {
 	if (InMemory()) {
-		in_memory_db = SQLiteDB::Open(path, false, true);
+		in_memory_db = SQLiteDB::Open(path, options, true);
 	}
 }
 

--- a/src/storage/sqlite_transaction.cpp
+++ b/src/storage/sqlite_transaction.cpp
@@ -17,8 +17,7 @@ SQLiteTransaction::SQLiteTransaction(SQLiteCatalog &sqlite_catalog, TransactionM
 		db = sqlite_catalog.GetInMemoryDatabase();
 	} else {
 		// on-disk database - open a new database connection
-		owned_db = SQLiteDB::Open(sqlite_catalog.path,
-		                          sqlite_catalog.access_mode == AccessMode::READ_ONLY ? true : false, true);
+		owned_db = SQLiteDB::Open(sqlite_catalog.path, sqlite_catalog.options, true);
 		db = &owned_db;
 	}
 }

--- a/test/sql/storage/attach_options.test
+++ b/test/sql/storage/attach_options.test
@@ -1,0 +1,24 @@
+# name: test/sql/storage/attach_options.test
+# description:
+# group: [sqlite_storage]
+
+require sqlite_scanner
+
+statement error
+ATTACH ':memory:' AS mem (TYPE SQLITE, BUSY_TIMEOUT 'hello')
+----
+Could not convert string
+
+statement error
+ATTACH ':memory:' AS mem (TYPE SQLITE, BUSY_TIMEOUT 99999999999)
+----
+busy_timeout out of range
+
+statement ok
+ATTACH ':memory:' AS mem (TYPE SQLITE, BUSY_TIMEOUT 0)
+
+statement ok
+DETACH mem
+
+statement ok
+ATTACH ':memory:' AS mem (TYPE SQLITE, JOURNAL_MODE 'WAL')


### PR DESCRIPTION
Fixes #82

This PR adds two new settings when attaching SQLite databases - `busy_timeout` and `journal_mode`.

* `busy_timeout` specifies a busy timeout in milliseconds, see [here](https://www.sqlite.org/c3ref/busy_timeout.html). This refers to the amount of time the process will wait if there is another process operating on the SQLite file. The default is now set to 5 seconds (i.e. `BUSY_TIMEOUT = 5000`), which is the same default used by [rusqlite](https://github.com/rusqlite/rusqlite/blob/28125461c74bb99f16699ada0b07843507fa3b5a/src/busy.rs#L34).
* `journal_mode` specifies a journaling mode, e.g. `journal_mode` can be `WAL`. See [here](https://www.sqlite.org/pragma.html#pragma_journal_mode) for more info.

Usage:

```sql
ATTACH 'file.db' AS f (TYPE SQLITE, BUSY_TIMEOUT 0);
ATTACH  'file.db' AS f (TYPE SQLITE, JOURNAL_MODE 'WAL');
```

This fixes the linked issue by specifying a busy time-out by default which prevents `database is locked` errors from appearing until after the timeout has passed. To restore previous behavior where the system would immediately return `database is locked` a `busy_timeout` of 0 can be specified.