### PR TITLE
Bind BLOBs as BLOBs instead of strings

### DIFF
--- a/src/include/sqlite_stmt.hpp
+++ b/src/include/sqlite_stmt.hpp
@@ -41,6 +41,7 @@ public:
 		throw InternalException("Unsupported type for SQLiteStatement::Bind");
 	}
 	void BindText(idx_t col, const string_t &value);
+	void BindBlob(idx_t col, const string_t &value);
 	void BindValue(Vector &col, idx_t c, idx_t r);
 	int GetType(idx_t col);
 	bool IsOpen();

--- a/src/sqlite_stmt.cpp
+++ b/src/sqlite_stmt.cpp
@@ -130,6 +130,10 @@ void SQLiteStatement::Bind(idx_t col, double value) {
 	SQLiteUtils::Check(sqlite3_bind_double(stmt, col + 1, value), db);
 }
 
+void SQLiteStatement::BindBlob(idx_t col, const string_t &value) {
+	SQLiteUtils::Check(sqlite3_bind_blob(stmt, col + 1, value.GetDataUnsafe(), value.GetSize(), nullptr), db);
+}
+
 void SQLiteStatement::BindText(idx_t col, const string_t &value) {
 	SQLiteUtils::Check(sqlite3_bind_text(stmt, col + 1, value.GetDataUnsafe(), value.GetSize(), nullptr), db);
 }
@@ -152,6 +156,8 @@ void SQLiteStatement::BindValue(Vector &col, idx_t c, idx_t r) {
 			Bind<double>(c, FlatVector::GetData<double>(col)[r]);
 			break;
 		case LogicalTypeId::BLOB:
+			BindBlob(c, FlatVector::GetData<string_t>(col)[r]);
+			break;
 		case LogicalTypeId::VARCHAR:
 			BindText(c, FlatVector::GetData<string_t>(col)[r]);
 			break;


### PR DESCRIPTION
refs #97 

When binding a BLOB from DuckDB to SQLite, it would be bound as TEXT instead of a SQLite BLOB. This PR adds a new `BindBlob` function, which is the same as `BindText`, but instead uses `sqlite3_bind_blob`.

I didn't test this locally since I had trouble compiling it myself, but the CI seems to pass just fine?