### PR TITLE
Fix #104: make CREATE OR REPLACE TABLE work in SQLite catalog instead of throwing an exception

### DIFF
--- a/src/storage/sqlite_schema_entry.cpp
+++ b/src/storage/sqlite_schema_entry.cpp
@@ -284,6 +284,9 @@ void SQLiteSchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
 	}
 	auto table = GetEntry(GetCatalogTransaction(context), info.type, info.name);
 	if (!table) {
+		if (info.if_not_found == OnEntryNotFound::RETURN_NULL) {
+			return;
+		}
 		throw InternalException("Failed to drop entry \"%s\" - could not find entry", info.name);
 	}
 	auto &transaction = SQLiteTransaction::Get(context, catalog);

--- a/test/sql/storage/attach_create_or_replace.test
+++ b/test/sql/storage/attach_create_or_replace.test
@@ -1,0 +1,21 @@
+# name: test/sql/storage/attach_create_or_replace.test
+# description:
+# group: [sqlite_storage]
+
+require sqlite_scanner
+
+statement ok
+ATTACH '__TEST_DIR__/attach_unnest.sqlite' AS tmp (TYPE SQLITE);
+
+statement ok
+USE tmp;
+
+statement ok
+CREATE OR REPLACE TABLE xs AS SELECT unnest(['foo', 'bar', 'baz']) AS x;
+
+query I
+SELECT * FROM xs;
+----
+foo
+bar
+baz


### PR DESCRIPTION
Fixes #104